### PR TITLE
[MISC] Improve strict installation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,21 @@ The snap can be installed directly from the Stap Store.  Follow the link below f
 git clone git@github.com:canonical/postgresql-snap.git
 cd postgresql-snap
 ```
+
 ### Installing and Configuring Prerequisites
 ```bash
 sudo snap install snapcraft
 sudo snap install lxd
 sudo lxd init --auto
 ```
+
 ### Packing and Installing the Snap
+In order to properly test the confinement of the snap, we must install it using the `--dangerous` flag,
+instead of the `--devmode` one. See snap [installation modes](https://snapcraft.io/docs/install-modes).
+
 ```bash
 snapcraft pack
-sudo snap install ./postgresql*.snap --devmode
+sudo snap install ./postgresql*.snap --dangerous
 ```
 
 ## License

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,7 +9,7 @@ def test_install():
         snapcraft = yaml.safe_load(file)
 
         subprocess.run(
-            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
+            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --dangerous".split(),
             check=True,
         )
 


### PR DESCRIPTION
This PR improves the strictness of the testing installation, in order to verify that the snap can be installed with the permissions setup in the `install` hook. This is not always the case, so we must verify using the `--dangerous` installation flag, instead of the `--devmode` one.

Suggested by @taurus-forever.