### PR TITLE
[DPE-7653] Add spread-based functional tests for postgresql snap.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - linux
+    - x64
+    - arm64
+    - amd64
+    - large
+    - jammy
+    - noble

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: Tests
+name: SNAP Build/Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,27 +18,46 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v32.1.0
 
-  smoke:
-    name: Smoke test snap
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+  test:
+    name: Test snap | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
+    timeout-minutes: 10
+    # runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", "${{ matrix.base.codename }}", large]
+    runs-on: "ubuntu-${{ matrix.base.version }}${{ matrix.platform.gh_suffix }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        base:
+          - { codename: jammy, version: 22.04 }
+          - { codename: noble, version: 24.04 }
+        platform:
+          - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
+          - { os: linux, arch: arm64, host_arch: arm64, gh_suffix: "-arm" }
     needs:
       - lint
       - build
     steps:
-      - name: Uninstall Postgresql
-        run: |
-          sudo apt --purge remove postgresql*
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install tox & poetry
-        run: |
-          pipx install tox
-          pipx install poetry
       - name: Download snap package(s)
         uses: actions/download-artifact@v4
         with:
-          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*-${{ matrix.platform.arch }}
           merge-multiple: true
+      - name: Add pipx to PATH
+        run: |
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          echo "/root/.local/bin" >> "${GITHUB_PATH}"
       - name: Run tests
-        run: tox run -e smoke
+        run: |
+          # lxd is necessary for spread
+          sudo snap install lxd
+          sudo adduser "$USER" lxd
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd waitready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd init --auto
+          # Workaround for Docker & LXD on same machine
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+
+          sudo snap install snapcraft --classic
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft test

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ instead of the `--devmode` one. See snap [installation modes](https://snapcraft.
 
 ```bash
 snapcraft pack
-sudo snap install ./postgresql*.snap --dangerous
+sudo snap install ./postgresql*.snap --dangerous --jailmode
 ```
 
 ### Testing Snap

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ snapcraft pack
 sudo snap install ./postgresql*.snap --dangerous
 ```
 
+### Testing Snap
+Using [Spread](https://github.com/canonical/spread):
+```bash
+snapcraft test                       # run all tests
+ls -la spread/tests/                 # list all tests
+snapcraft test -- spread/tests/smoke # run one test suite
+snapcraft test --debug               # to open shell for failed test
+```
+
 ## License
 The PostgreSQL Snap is free software, distributed under the Apache
 Software License, version 2.0. See

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,7 +11,7 @@ suites:
   spread/tests/:
     summary: General integration tests
     prepare: |
-      sudo apt --purge remove postgresql*
+      apt --purge remove postgresql*
     prepare-each: |
       snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
     restore-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,23 @@
+project: postgresql-snap
+
+backends:
+  craft:
+    type: craft
+    systems:
+      - ubuntu-24.04
+      - ubuntu-22.04
+
+suites:
+  spread/tests/:
+    summary: General integration tests
+    prepare: |
+      sudo apt --purge remove postgresql*
+    prepare-each: |
+      snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
+    restore-each: |
+      snap remove postgresql --purge --terminate
+
+exclude:
+  - .git
+
+kill-timeout: 1h

--- a/spread/.extension
+++ b/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | grep ",$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/spread/tests/aliases/task.yaml
+++ b/spread/tests/aliases/task.yaml
@@ -1,0 +1,9 @@
+summary: PostgreSQL CLI tools tests
+
+execute: |
+  echo "Testing SNAP aliases (no auto-connect in --jailmode)..."
+
+  snap alias postgresql.psql psql
+  psql --help
+  psql -U postgres -h /tmp -c "SELECT NOW();"
+

--- a/spread/tests/cli_cluster/task.yaml
+++ b/spread/tests/cli_cluster/task.yaml
@@ -1,0 +1,30 @@
+summary: PostgreSQL cluster CLIs tests
+
+execute: |
+  echo "Testing *cluster ..."
+
+  postgresql.lsclusters
+  postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+
+  postgresql.ctlcluster --skip-systemctl-redirect 16 main status
+  postgresql.ctlcluster --skip-systemctl-redirect 16 main stop
+  postgresql.ctlcluster --skip-systemctl-redirect 16 main status && exit 1 || true # failure expected
+  postgresql.ctlcluster --skip-systemctl-redirect 16 main start
+  postgresql.ctlcluster --skip-systemctl-redirect 16 main status
+  postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+
+  postgresql.createcluster 16 test1
+  postgresql.lsclusters 16 test1
+  postgresql.ctlcluster --skip-systemctl-redirect 16 test1 start
+  postgresql.lsclusters 16 test1
+  postgresql.psql -U postgres -h /tmp -p 5433 -d postgres -c "SELECT NOW();"
+
+  postgresql.lsclusters 16
+  postgresql.renamecluster 16 test1 test123
+  postgresql.lsclusters 16
+
+
+  postgresql.lsclusters 16 test123
+  postgresql.dropcluster --stop 16 test123
+  postgresql.lsclusters 16 test123 && exit 1 || true # failure expected
+  

--- a/spread/tests/cli_config/task.yaml
+++ b/spread/tests/cli_config/task.yaml
@@ -1,0 +1,8 @@
+summary: PostgreSQL config CLI tests
+
+execute: |
+  echo "Testing config tools..."
+
+  postgresql.config
+  postgresql.conftool 16 main show max_connections
+  postgresql.conftool 16 main show all

--- a/spread/tests/cli_ctl/task.yaml
+++ b/spread/tests/cli_ctl/task.yaml
@@ -1,0 +1,18 @@
+summary: PostgreSQL ctl CLI tests
+
+execute: |
+  echo "Testing createuser, createdb, ctl..."
+
+  postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+
+  postgresql.createuser -U postgres -h /tmp mynewuser
+  postgresql.psql -U postgres -h /tmp -p 5432 -d postgres -c "\du"
+  postgresql.psql -U postgres -h /tmp -p 5432 -d postgres \
+    -c "select * from pg_user where usename='mynewuser'"
+
+  postgresql.createdb -U postgres -h /tmp -p 5432 mydatabase
+  postgresql.psql -U postgres -h /tmp -p 5432 -d postgres -c "\l"
+  postgresql.psql -U postgres -h /tmp -d mydatabase -c "SELECT NOW();"
+
+  postgresql.ctl status -D /var/lib/postgresql/16/main/
+

--- a/spread/tests/cli_dump/task.yaml
+++ b/spread/tests/cli_dump/task.yaml
@@ -1,0 +1,24 @@
+summary: PostgreSQL dump CLI tests
+
+execute: |
+  echo "Testing dump/restore tools..."
+
+  postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+
+  postgresql.psql -U postgres -h /tmp -c "
+    CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT);
+    INSERT INTO test (name) VALUES ('test1');
+    DELETE FROM test WHERE name='test1';
+    SELECT * from test;
+  "
+
+  postgresql.dump -c -C -U postgres -h /tmp -d postgres > mydb.sql
+  postgresql.psql -U postgres -h /tmp -c "DROP TABLE test;"
+  postgresql.psql -U postgres -h /tmp < mydb.sql
+  postgresql.psql -U postgres -h /tmp -c "SELECT * from test;"
+
+  postgresql.dumpall -c -U postgres -h /tmp > all.sql
+  postgresql.psql -U postgres -h /tmp -c "DROP TABLE test;"
+  postgresql.psql -U postgres -h /tmp < all.sql
+  postgresql.psql -U postgres -h /tmp -c "SELECT * from test;"
+

--- a/spread/tests/cli_isready/task.yaml
+++ b/spread/tests/cli_isready/task.yaml
@@ -1,0 +1,10 @@
+summary: PostgreSQL isready CLI tests
+
+execute: |
+  echo "Testing isready..."
+
+  postgresql.isready
+
+  postgresql.isready -h /tmp -p 5432
+
+  postgresql.isready -h /tmp -p 5555 && exit 1 || true # failure expected

--- a/spread/tests/cli_pgbench/task.yaml
+++ b/spread/tests/cli_pgbench/task.yaml
@@ -1,0 +1,9 @@
+summary: PostgreSQL pgbench CLI tests
+
+execute: |
+  echo "Testing pgbench..."
+
+  postgresql.createdb -U postgres -h /tmp -p 5432 mybench
+
+  postgresql.pgbench -U postgres -h /tmp -p 5432 -d mybench --initialize
+  postgresql.pgbench -U postgres -h /tmp -p 5432 -d mybench -T 10

--- a/spread/tests/cli_psql/task.yaml
+++ b/spread/tests/cli_psql/task.yaml
@@ -1,0 +1,13 @@
+summary: PostgreSQL psql CLI tests
+
+execute: |
+  echo "Testing psql..."
+
+  postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+
+  postgresql.psql -U postgres -h /tmp -c "
+    CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT);
+    INSERT INTO test (name) VALUES ('test1'), ('test2');
+    DELETE FROM test WHERE name='test1';
+    SELECT * from test;
+  "

--- a/spread/tests/smoke.py/task.yaml
+++ b/spread/tests/smoke.py/task.yaml
@@ -1,0 +1,13 @@
+summary: PostgreSQL smoke Python tests
+
+execute: |
+  snap install astral-uv --classic
+  uv tool install tox
+  uv tool install poetry
+  export PATH="$PATH:$HOME/.local/bin"
+
+  tox run -e smoke
+
+  uv tool uninstall tox
+  uv tool install poetry
+  snap remove astral-uv --purge --terminate

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -1,0 +1,28 @@
+summary: PostgreSQL SNAP smoke tests
+
+execute: |
+  echo "Running smoke test..."
+  postgresql.psql -U postgres -h /tmp -c "SELECT version();"
+
+  echo "Ensure all tools have been shipped.."
+  postgresql.archivecleanup --help
+  postgresql.basebackup --help
+  postgresql.config --help
+  postgresql.conftool --help
+  # postgresql.createcluster --help # Missing --help
+  postgresql.createdb --help
+  # postgresql.createuser --help # Missing --help
+  postgresql.ctl --help
+  postgresql.ctlcluster 16 main status # Missing --help
+  # postgresql.dropcluster --help # Missing --help
+  postgresql.dump --help
+  postgresql.dumpall --help
+  postgresql.isready --help
+  postgresql.lsclusters --help
+  postgresql.pgbench --help
+  postgresql.psql --help
+  postgresql.receivewal --help
+  postgresql.recvlogical --help
+  # postgresql.renamecluster --help # Missing --help
+  postgresql.restore --help
+

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -2,7 +2,9 @@ summary: PostgreSQL SNAP smoke tests
 
 execute: |
   echo "Running smoke test..."
-  postgresql.psql -U postgres -h /tmp -c "SELECT version();"
+  SNAP_VERSION=$(awk -F\' '/version/{print $2}' "${PROJECT_PATH}"/snap/snapcraft.yaml)
+  postgresql.psql -U postgres -h /tmp -c "SELECT version();" | \
+    grep "^ PostgreSQL ${SNAP_VERSION:-error}"
 
   echo "Ensure all tools have been shipped.."
   postgresql.archivecleanup --help

--- a/spread/tests/storage/task.yaml
+++ b/spread/tests/storage/task.yaml
@@ -1,0 +1,37 @@
+summary: PostgreSQL storage tests
+
+execute: |
+  echo "Creating test data..."
+  postgresql.psql -U postgres -h /tmp -c "
+    CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT);
+    INSERT INTO test (name) VALUES ('test1');
+    SELECT * from test;
+  "
+
+  echo "Create a storage to keep you data/logs..."
+  mkdir -p /srv/mypgdata/data /srv/mypgdata/logs
+
+  echo "Stop PostgreSQL DB to move data..."
+  snap stop postgresql.postgresql
+
+  echo "Move current data/logs..."
+  cp -a /var/snap/postgresql/common/var/lib/postgresql/* /srv/mypgdata/data
+  cp -a /var/snap/postgresql/common/var/log/postgresql/* /srv/mypgdata/logs
+
+  echo "Mount data/logs storage inside SNAP..."
+  mount --bind /srv/mypgdata/data /var/snap/postgresql/common/var/lib/postgresql
+  mount --bind /srv/mypgdata/logs /var/snap/postgresql/common/var/log/postgresql
+
+  echo "Start PostgreSQL DB..."
+  snap start postgresql.postgresql
+  timeout 10 /bin/bash -c "while ! postgresql.isready ; do echo Waiting for postgresql...; sleep 1; done"
+
+  echo "Checking test data aftert in new location..."
+  postgresql.psql -U postgres -h /tmp -c "SELECT * from test;"
+
+  echo "Cleaning PG mounts to purge SNAP on spread restore"
+  snap stop postgresql.postgresql
+  umount /var/snap/postgresql/common/var/lib/postgresql
+  umount /var/snap/postgresql/common/var/log/postgresql
+
+  echo "Storage test completed."

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,18 +3,6 @@ import subprocess
 import time
 import pytest
 
-
-def test_install():
-    with open("snap/snapcraft.yaml") as file:
-        snapcraft = yaml.safe_load(file)
-
-        subprocess.run(
-            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --dangerous".split(),
-            check=True,
-        )
-
-
-@pytest.mark.run(after="test_install")
 def test_all_apps():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)
@@ -48,7 +36,6 @@ def test_all_apps():
                     raise e
 
 
-@pytest.mark.run(after="test_install")
 def test_all_services():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)
@@ -76,7 +63,6 @@ def test_all_services():
                     raise e
 
 
-@pytest.mark.run(after="test_install")
 def test_version():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)


### PR DESCRIPTION
## Issue: 

No tests were executed on arm64. The latest Ubuntu LTS tested only.
The basic tox/smoke was available only and didn't use spread
(however `snapcraft test` is available nowadays).

## Solution:

Add spread-based tests for postgresql snap using `snapcraft test`.
Add functional tests for all commands shipped by snap.
Testing snap behaviour on both Ubuntu LTS 22.04 and 24.04 * AMD/ARM.
Updated README.