### PR TITLE
DPE-8296 Bump PostgreSQL to 16.10 (metapackage pinning)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -152,7 +152,7 @@ parts:
   postgres-debs:
     plugin: nil
     stage-packages:
-      - postgresql=16+257build1
+      - postgresql=16+257build1.1
       - util-linux
       - locales-all
       - coreutils


### PR DESCRIPTION
We have bumped PG 16 to 16.10 in the last commit, but missed the metapackage pinning bump:
https://changelogs.ubuntu.com/changelogs/pool/main/p/postgresql-common/postgresql-common_257build1.1/changelog