### PR TITLE
GH#29 Allow other snaps using PostgreSQL snap via slots

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,8 +75,6 @@ apps:
     command: usr/bin/createuser
   archivecleanup:
     command: archivecleanup.sh
-  # buildext:
-  #   command: usr/bin/pg_buildext
   createcluster:
     command: create-cluster.sh
     plugs:
@@ -89,10 +87,6 @@ apps:
     command: usr/bin/pg_restore
     plugs:
       - network
-  # upgradecluster:
-  #   command: usr/bin/pg_upgradecluster
-  # backupcluster:
-  #   command: usr/bin/pg_backupcluster
   config:
     command: usr/bin/pg_config
   dump:
@@ -103,10 +97,6 @@ apps:
     command: usr/bin/pg_lsclusters
   recvlogical:
     command: usr/bin/pg_recvlogical
-  # restorecluster:
-  #   command: usr/bin/pg_restorecluster
-  # virtualenv:
-  #   command: usr/bin/pg_virtualenv
   basebackup:
     command: usr/bin/pg_basebackup
   conftool:
@@ -132,8 +122,6 @@ apps:
     plugs:
       - network
       - network-bind
-  # updatedicts:
-  #   command: usr/sbin/pg_updatedicts
   pgbench:
     command: usr/bin/pgbench
   psql:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,17 @@ plugs:
   shared-memory:
     private: true
 
+# This slot exposes all of this snap to any other snap to use postgresql without
+# bundling any of postgresql. This allows multiple snaps to use the postgresql
+# snap however they see fit, without duplicating postgresql files on the device
+# (by bundling postgresql with every snap)
+slots:
+  postgresql:
+    interface: content
+    content: bins
+    read:
+      - $SNAP
+
 hooks:
   install:
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -152,7 +152,7 @@ parts:
   postgres-debs:
     plugin: nil
     stage-packages:
-      - postgresql=16+257build1
+      - postgresql=16+257build1.1
       - util-linux
       - locales-all
       - coreutils


### PR DESCRIPTION
In the past, there were no easy way to allow other snaps using PostgreSQL snap, adding a slot to allow it.

Fixes: https://github.com/canonical/postgresql-snap/issues/29

Thank you @dilyn-corner for feedback and improvements!
