### PR TITLE
DPE-9018 Bump PostgreSQL 16.11

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: postgresql
 base: core24
-version: '16.10'
+version: '16.11'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management


### PR DESCRIPTION
The new PostgreSQL 16.11 has been released, bumping PostgreSQL slim snap.