### PR TITLE
[DPE-9000] Add permissions to workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ concurrency:
 on:
   pull_request:
 
+permissions: {}
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v42.0.0
+    permissions: {}
 
   release:
     name: Release snap


### PR DESCRIPTION
# Issue

GH Security tab reports an issues due to missing default permission on workflow.

# Solution
    
Add permissions to workflows to keep the house clean.
