### PR TITLE
[DPE-9455] Bump PostgreSQL to 16.13

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: postgresql
 base: core24
-version: '16.11'
+version: '16.13'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 16.11.

# Solution:

Update PostgreSQL to 16.13.