### PR TITLE
[DPE-9455] Bump PostgreSQL to 18.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: postgresql
 base: core26
 build-base: devel # TODO: remove before stable release
-version: '18.1'
+version: '18.3'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management


### PR DESCRIPTION
# Issue:

We ship outdated PostgreSQL 18.1.

# Solution:

Update PostgreSQL to 18.3.