### PR TITLE
Add zizmor and update dpw to v48 (18)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,15 +9,36 @@ concurrency:
 on:
   pull_request:
 
-permissions: {}
 jobs:
+  lint-workflows:
+    name: Lint .github/workflows/
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v48.0.4
+    permissions:
+      contents: read
+
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.0.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: tox run -e lint
+        run: tox run -e lint
+    permissions: {}
 
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v42.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v48.0.4
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   test:
     name: Test snap | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
@@ -34,11 +55,14 @@ jobs:
           - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
           - { os: linux, arch: arm64, host_arch: arm64, gh_suffix: "-arm" }
     needs:
+      - lint-workflows
       - lint
       - build
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download snap package(s)
         uses: actions/download-artifact@v8
         with:
@@ -66,3 +90,4 @@ jobs:
           sudo snap refresh snapd --beta  # TODO: remove once snapd 2.74 is out
           sudo snap install snapcraft --classic --channel latest/beta/sd
           sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft test
+    permissions: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,18 +17,21 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v42.0.1
-    permissions: {}
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v48.0.4
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: read
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v42.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap_edge.yaml@v48.0.4
     with:
-      channel: ${{ github.ref_name }}
+      track: '18'
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN_EDGE }}
     permissions:
-      contents: write  # Needed to create GitHub release
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to create git tags

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,31 @@
+rules:
+  # Allowlist trusted actions
+  forbidden-uses:
+    config:
+      # Actions in this list have remote code execution in our workflows. Even if the workflow has
+      # limited permissions, those can be escaped. See https://github.com/AdnaneKhan/Cacheract and
+      # "But Wait, There’s More" section of
+      # https://www.praetorian.com/blog/codeqleaked-public-secrets-exposure-leads-to-supply-chain-attack-on-github-codeql/
+      # In general, this list should be limited to organizations that we trust to have a baseline
+      # level of operational security. Avoid adding actions that could be replaced with a few lines
+      # of bash.
+      allow:  # Get approval from your manager before adding actions to this list.
+        - canonical/*
+        - actions/*
+        - docker/login-action
+        - tiobe/tics-github-action
+  # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
+  # compromised, but they also cannot be security patched.
+  # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have
+  # a baseline level of operational security.
+  # Our actions usage involves several long-term support branches and reusable workflows (which
+  # themselves use actions). For our threat model, we believe it is safer to limit actions usage to
+  # organizations we trust and immediately receive security patching across our many branches than
+  # it is to pin actions to a commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        canonical/*: ref-pin
+        actions/*: ref-pin
+        docker/login-action: ref-pin
+        tiobe/tics-github-action: ref-pin


### PR DESCRIPTION
https://discourse.canonical.com/t/security-update-action-requested/7120

After this PR is merged, the following secret actions will be required:
- Revoke and delete these secrets:
  ```
  SNAP_STORE_TOKEN
  ```
- Create these secrets (new credentials) for the `edge` environment (do **not** add as repository secrets)
  ```
  SNAP_STORE_TOKEN_EDGE
  ```
    - Follow these instructions: https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_snap_edge.md#step-2-add-snap-store-token