### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,7 +1,6 @@
 import yaml
 import subprocess
 import time
-import pytest
 
 def test_all_apps():
     with open("snap/snapcraft.yaml") as file:


### PR DESCRIPTION
Remove the unused `pytest` import from `tests/test_smoke.py`.

- **General fix:** delete imports that are not referenced.
- **Best fix for this file:** remove line 4 (`import pytest`) and keep all other imports unchanged.
- **Scope:** only the import section at the top of `tests/test_smoke.py`.
- **No additional methods/imports/definitions** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._