### PR TITLE
Add metadata fields (PG16)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,6 @@ license: Apache-2.0
 issues: https://github.com/canonical/postgresql-snap/issues
 source-code: https://github.com/canonical/postgresql-snap
 website: https://canonical.com/data/postgresql
-donation: https://thanks.dev/
 
 platforms:
   amd64:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,13 @@ summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management
   system emphasizing extensibility and SQL compliance.
+title: PostgreSQL
+contact: https://matrix.to/#/#charmhub-data-platform:ubuntu.com
+license: Apache-2.0
+issues: https://github.com/canonical/postgresql-snap/issues
+source-code: https://github.com/canonical/postgresql-snap
+website: https://canonical.com/data/postgresql
+donation: https://thanks.dev/
 
 platforms:
   amd64:


### PR DESCRIPTION
# Issue

The latest snapcraft (8.14.5) produces warnings on `snapcraft pack`:
```
Lint warnings:
- metadata: Metadata field 'title' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#title)
- metadata: Metadata field 'contact' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#contact)
- metadata: Metadata field 'license' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#license)
Lint information:
- metadata: Metadata field 'donation' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#donation)
- metadata: Metadata field 'issues' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#issues)
- metadata: Metadata field 'source-code' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#source-code)
- metadata: Metadata field 'website' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#website)
```

# Solution

Fix most warnings by adding all the necessary fields.
The donate one should be muted eventually.