### PR TITLE
Fix lint warnings 'unused library' (PG16)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,6 +172,12 @@ parts:
       sed -i \
         "s/'pg_ctlcluster',/'pg_ctlcluster', '--skip-systemctl-redirect',/g" \
         $SNAPCRAFT_STAGE/usr/bin/pg_renamecluster
+    prime:
+      # Mute lint by removing unnecessary APT Recommends
+      - -usr/lib/*/libexslt.so*
+      - -usr/lib/*/libicuio.so*
+      - -usr/lib/*/libicutest.so*
+      - -usr/lib/*/libicutu.so*
     organize:
       etc/postgresql: default-config/etc/postgresql
       etc/postgresql-common: default-config/etc/postgresql-common

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,7 +173,8 @@ parts:
         "s/'pg_ctlcluster',/'pg_ctlcluster', '--skip-systemctl-redirect',/g" \
         $SNAPCRAFT_STAGE/usr/bin/pg_renamecluster
     prime:
-      # Mute lint by removing unnecessary APT Recommends
+      # Mute lint by removing unnecessary for PostgreSQL run-time libraries
+      # which are shipped as APT Depends packages: libxslt1.1, libicu74.
       - -usr/lib/*/libexslt.so*
       - -usr/lib/*/libicuio.so*
       - -usr/lib/*/libicutest.so*


### PR DESCRIPTION
# Issue 

> snapcraft pack:
```
- library: libexslt.so.0: unused library 'usr/lib/x86_64-linux-gnu/libexslt.so.0.8.21'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: libicuio.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicuio.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: libicutest.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicutest.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
- library: libicutu.so.74: unused library 'usr/lib/x86_64-linux-gnu/libicutu.so.74.2'. (https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter)
```

# Solution

Exclude them on prime stage as those libraries have been installed as
APT Depends during the SNAP unpacking and are unnecessary for
PostgreSQL SNAP workload runtime. There is no other ways to fix lint warnings.