### PR TITLE
[DPE-7547] Fix scripts network access (PG18)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,8 @@ apps:
     command: drop-cluster.sh
   isready:
     command: usr/bin/pg_isready
+    plugs:
+      - network
   restore:
     command: usr/bin/pg_restore
     plugs:
@@ -107,8 +109,12 @@ apps:
     command: usr/bin/pg_lsclusters
   recvlogical:
     command: usr/bin/pg_recvlogical
+    plugs:
+      - network
   basebackup:
     command: usr/bin/pg_basebackup
+    plugs:
+      - network
   conftool:
     command: conftool.sh
   ctl:
@@ -127,6 +133,8 @@ apps:
       - network
   receivewal:
     command: usr/bin/pg_receivewal
+    plugs:
+      - network
   renamecluster:
     command: rename-cluster.sh
     plugs:
@@ -134,6 +142,8 @@ apps:
       - network-bind
   pgbench:
     command: usr/bin/pgbench
+    plugs:
+      - network
   psql:
     command: usr/bin/psql
     plugs:

--- a/spread.yaml
+++ b/spread.yaml
@@ -12,11 +12,10 @@ suites:
     summary: General integration tests
     prepare: |
       apt --purge remove postgresql*
-      snap install snapd --edge  # TODO: remove once snapd 2.74 is out
-      snap refresh snapd --edge  # TODO: remove once snapd 2.74 is out
-      snap install core26 --edge # TODO: remove once core26 latest/stable is out
     prepare-each: |
       snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
+      postgresql.psql -U postgres \
+        -c "ALTER USER postgres WITH PASSWORD 'pgpass'"
     restore-each: |
       snap remove postgresql --purge --terminate
 

--- a/spread/.extension
+++ b/spread/.extension
@@ -37,9 +37,11 @@ prepare() {
     snap wait system seed.loaded
     snap refresh --hold
 
-    if systemctl is-enabled unattended-upgrades.service; then
-        systemctl stop unattended-upgrades.service
-        systemctl mask unattended-upgrades.service
+    if systemctl show unattended-upgrades.service --property=LoadState | grep -q 'LoadState=loaded'; then
+        if systemctl is-enabled unattended-upgrades.service; then
+            systemctl stop unattended-upgrades.service
+            systemctl mask unattended-upgrades.service
+        fi
     fi
 }
 
@@ -62,6 +64,9 @@ restore_each() {
     true
 }
 
+# If you want to allocate LXD VMs from remotes other than
+# "ubuntu", such as "ubuntu-daily", this function should be
+# modified to point there.
 allocate_lxdvm() {
     name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
     system=$(echo "$SPREAD_SYSTEM" | tr / -)

--- a/spread/tests/aliases/task.yaml
+++ b/spread/tests/aliases/task.yaml
@@ -6,4 +6,5 @@ execute: |
   snap alias postgresql.psql psql
   psql --help
   psql -U postgres -h /tmp -c "SELECT NOW();"
+  PGPASSWORD=pgpass psql -U postgres -h 127.0.0.1 -c "SELECT NOW();"
 

--- a/spread/tests/cli_cluster/task.yaml
+++ b/spread/tests/cli_cluster/task.yaml
@@ -5,6 +5,7 @@ execute: |
 
   postgresql.lsclusters
   postgresql.psql -U postgres -h /tmp -c "SELECT NOW();"
+  PGPASSWORD=pgpass postgresql.psql -U postgres -h 127.0.0.1 -c "SELECT NOW();"
 
   postgresql.ctlcluster --skip-systemctl-redirect 18 main status
   postgresql.ctlcluster --skip-systemctl-redirect 18 main stop

--- a/spread/tests/cli_dump/task.yaml
+++ b/spread/tests/cli_dump/task.yaml
@@ -13,11 +13,13 @@ execute: |
   "
 
   postgresql.dump -c -C -U postgres -h /tmp -d postgres > mydb.sql
+  PGPASSWORD=pgpass postgresql.dump -c -C -U postgres -h 127.0.0.1 -d postgres > /dev/null
   postgresql.psql -U postgres -h /tmp -c "DROP TABLE test;"
   postgresql.psql -U postgres -h /tmp < mydb.sql
   postgresql.psql -U postgres -h /tmp -c "SELECT * from test;"
 
   postgresql.dumpall -c -U postgres -h /tmp > all.sql
+  PGPASSWORD=pgpass postgresql.dumpall -c -U postgres -h 127.0.0.1 > /dev/null
   postgresql.psql -U postgres -h /tmp -c "DROP TABLE test;"
   postgresql.psql -U postgres -h /tmp < all.sql
   postgresql.psql -U postgres -h /tmp -c "SELECT * from test;"

--- a/spread/tests/cli_isready/task.yaml
+++ b/spread/tests/cli_isready/task.yaml
@@ -6,5 +6,7 @@ execute: |
   postgresql.isready
 
   postgresql.isready -h /tmp -p 5432
+  postgresql.isready -h 127.0.0.1 -p 5432
 
   postgresql.isready -h /tmp -p 5555 && exit 1 || true # failure expected
+  postgresql.isready -h 127.0.0.1 -p 5555 && exit 1 || true # failure expected

--- a/spread/tests/cli_pgbench/task.yaml
+++ b/spread/tests/cli_pgbench/task.yaml
@@ -6,4 +6,6 @@ execute: |
   postgresql.createdb -U postgres -h /tmp -p 5432 mybench
 
   postgresql.pgbench -U postgres -h /tmp -p 5432 -d mybench --initialize
-  postgresql.pgbench -U postgres -h /tmp -p 5432 -d mybench -T 10
+  postgresql.pgbench -U postgres -h /tmp -p 5432 -d mybench -T 5
+
+  PGPASSWORD=pgpass postgresql.pgbench -U postgres -h 127.0.0.1 -p 5432 -d mybench -T 5


### PR DESCRIPTION
* add necessary network plugs
* add new tests to ensure scripts using network
* sync spread .extension from upstream: snapcraft v8.14.5 r17634
* remove workarounds for lack of stable core26/snapd