### PR TITLE
[DPE-10011] Bump PostgreSQL to 18.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: postgresql
 base: core26
 build-base: devel # TODO: remove before stable release
-version: '18.3'
+version: '18.4'
 summary: PostgreSQL in a snap.
 description: |
   PostgreSQL is a free and open-source relational database management


### PR DESCRIPTION
New PostgreSQL 18.4 is our with Mythos CVE fixes.... bumping snap with priority.