### PR TITLE
[DPE-10011] Update GH CI workflow (use stable *craft/snapd)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,9 +86,6 @@ jobs:
           # Workaround for Docker & LXD on same machine
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
-
-          sudo snap install snapd --beta  # TODO: remove once snapd 2.74 is out
-          sudo snap refresh snapd --beta  # TODO: remove once snapd 2.74 is out
-          sudo snap install snapcraft --classic --channel latest/beta/sd
+          sudo snap install snapcraft --classic
           sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft test
     permissions: {}


### PR DESCRIPTION
Initially, to build/test on core26 we had to use new/edge components.
The 26.04 is out and we can start using stable components.