### PR TITLE
[DPE-7547] Start testing 26.04 on GH runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         base:
           - { codename: jammy, version: 22.04 }
           - { codename: noble, version: 24.04 }
-        # - { codename: resolute, version: 26.04 }
+          - { codename: resolute, version: 26.04 }
         platform:
           - { os: linux, arch: amd64, host_arch: x64, gh_suffix: "" }
           - { os: linux, arch: arm64, host_arch: arm64, gh_suffix: "-arm" }


### PR DESCRIPTION
# Issue

Ubuntu 26.04 is the latest LTS. Let's test our snap there.

# Solution

GH runners 26.04 are GA: https://github.com/actions/runner-images/releases?q=26.04&expanded=true
Let's give them a spin.