### PR TITLE
[DPE-7547] Fix building for core26 + mute lint warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: postgresql
 base: core26
-build-base: devel # TODO: remove before stable release
 version: '18.4'
 summary: PostgreSQL in a snap.
 description: |
@@ -16,7 +15,7 @@ website: https://canonical.com/data/postgresql
 platforms:
   amd64:
   arm64:
-grade: devel # TODO: switch to stable before release
+grade: stable
 confinement: strict
 
 system-usernames:
@@ -186,6 +185,14 @@ parts:
       sed -i \
         "s/'pg_ctlcluster',/'pg_ctlcluster', '--skip-systemctl-redirect',/g" \
         $SNAPCRAFT_STAGE/usr/bin/pg_renamecluster
+    prime:
+      # Mute lint by removing unnecessary for PostgreSQL run-time libraries
+      # which are shipped as APT Depends packages: libxslt1.1, libicu74.
+      - -usr/lib/*/libexslt.so*
+      - -usr/lib/*/libicuio.so*
+      - -usr/lib/*/libicutest.so*
+      - -usr/lib/*/libicutu.so*
+      - -usr/lib/*/liburing-ffi.so*
     organize:
       etc/postgresql: default-config/etc/postgresql
       etc/postgresql-common: default-config/etc/postgresql-common


### PR DESCRIPTION
The snapcraft 9.0.0 and core26 are now stable, we should
stop using devel grade, otherwise CI/CD builds are failing:

> Launching managed ubuntu devel instance...
> Creating new instance from remote
> Creating new base instance from remote
> Creating new instance from base instance
> Starting instance
> snapcraft internal error: ValueError("'26.10' is not a valid BuilddBaseAlias")

Muted lint warnings:
> - library: libexslt.so.0: unused library 'usr/lib/riscv64-linux-gnu/libexslt.so.0.8.25'
> - library: libicuio.so.78: unused library 'usr/lib/riscv64-linux-gnu/libicuio.so.78.2'
> - library: libicutest.so.78: unused library 'usr/lib/riscv64-linux-gnu/libicutest.so.78.2'
> - library: liburing-ffi.so.2: unused library 'usr/lib/riscv64-linux-gnu/liburing-ffi.so.2.14'