### PR TITLE
[DPE-10765] Silence AppArmor oom_score_adj denials on each postgres fork

### DIFF
--- a/docs/oom.md
+++ b/docs/oom.md
@@ -1,0 +1,76 @@
+# OOM tuning
+
+When Linux runs out of memory, the kernel OOM killer picks a victim process based on its
+`oom_score`, which can be biased per process via `/proc/<pid>/oom_score_adj`
+(`-1000` = never kill, `0` = default, `1000` = kill first).
+
+## Default behavior of the snap
+
+Debian/Ubuntu APT packages of PostgreSQL start the postmaster with `oom_score_adj=-900`
+(strongly protected) while each child backend resets itself to `0`, so a runaway query
+can be killed without taking down the whole database. Inside the
+[PostgreSQL snap](https://snapcraft.io/postgresql) this mechanism cannot work: strict
+snap confinement forbids writing `/proc/<pid>/oom_score_adj` (no snapd interface grants
+it), so **all PostgreSQL processes run with the default `oom_score_adj=0`** — the same
+as any ordinary process or a PostgreSQL container image.
+
+This default is safe for most deployments:
+
+* If a backend is OOM-killed, the postmaster performs automatic crash recovery.
+* If the postmaster is OOM-killed, systemd restarts the `postgresql` service.
+
+## Protecting PostgreSQL with `resilience.vitality-hint`
+
+To shield PostgreSQL from the OOM killer, use snapd's built-in
+[service vitality](https://snapcraft.io/docs/system-options) option. It is applied by
+systemd from outside the snap's confinement, so no interface is needed:
+
+```shell
+sudo snap set system resilience.vitality-hint=postgresql
+sudo snap restart postgresql.postgresql
+```
+
+The option takes a comma-separated list of snap names ranked by importance: the snap in
+position *N* gets `OOMScoreAdjust=-900 + N` on its services (`-900` is reserved for
+snapd itself), so the example above runs PostgreSQL with `oom_score_adj=-899`.
+
+Verify the result:
+
+```shell
+systemctl show -p OOMScoreAdjust snap.postgresql.postgresql.service
+cat /proc/$(pgrep -o -x postgres)/oom_score_adj
+```
+
+To revert to the default:
+
+```shell
+sudo snap unset system resilience.vitality-hint
+sudo snap restart postgresql.postgresql
+```
+
+## Caveat: the whole process tree is protected
+
+Unlike the APT packages, this protection applies to **every** PostgreSQL process:
+child backends inherit `-899` and, due to the confinement restriction above, cannot
+reset themselves to `0`. Upstream PostgreSQL
+[advises against](https://www.postgresql.org/docs/current/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT)
+protecting backends, because a single memory-hungry query then deflects OOM kills onto
+the rest of the system.
+
+In practice:
+
+* On a **dedicated database host**, whole-tree protection is usually the right call —
+  everything on the machine exists to serve PostgreSQL.
+* On a **shared host**, prefer the default (`0`) and rely on crash recovery, or address
+  memory pressure directly (`work_mem`, connection limits, swap/overcommit settings).
+
+## Note on `PG_OOM_ADJUST_FILE`
+
+The snap builds `pg_ctlcluster` with `PG_OOM_ADJUST_FILE=/dev/null` as the default so
+that the (inevitably denied) per-fork writes to `oom_score_adj` do not flood the kernel
+log with AppArmor denials (see
+[issue #190](https://github.com/canonical/postgresql-snap/issues/190)). The value can
+be overridden per cluster in
+`/var/snap/postgresql/common/etc/postgresql/18/main/environment`, but pointing it back
+at `/proc/self/oom_score_adj` only restores the denials — the write stays forbidden by
+confinement.

--- a/docs/oom.md
+++ b/docs/oom.md
@@ -71,6 +71,13 @@ that the (inevitably denied) per-fork writes to `oom_score_adj` do not flood the
 log with AppArmor denials (see
 [issue #190](https://github.com/canonical/postgresql-snap/issues/190)). The value can
 be overridden per cluster in
-`/var/snap/postgresql/common/etc/postgresql/18/main/environment`, but pointing it back
-at `/proc/self/oom_score_adj` only restores the denials — the write stays forbidden by
-confinement.
+`/var/snap/postgresql/common/etc/postgresql/18/main/environment`. The file uses
+`postgresql.conf` syntax, so the value must be single-quoted — an unquoted path makes
+`pg_ctlcluster` fail with an `invalid line` error and the cluster does not start:
+
+```
+PG_OOM_ADJUST_FILE = '/proc/self/oom_score_adj'
+```
+
+Note that pointing it back at `/proc/self/oom_score_adj` only restores the denials —
+the write stays forbidden by confinement.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -178,6 +178,13 @@ parts:
       # Pass user in startup checks
       sed -i "s/psql -h /psql -U postgres -h /g" \
         $SNAPCRAFT_STAGE/usr/bin/pg_ctlcluster
+      # Don't have postgres children reset oom_score_adj: strict confinement
+      # denies the write, spamming the kernel log with AppArmor denials on
+      # every fork (issue #190). The adjustment is a no-op in the snap anyway,
+      # as the root-only -900 postmaster protection never runs (we setpriv to
+      # _daemon_ first). Overridable via the cluster 'environment' file.
+      sed -i 's|"/proc/self/oom_score_adj"|"/dev/null"|' \
+        $SNAPCRAFT_STAGE/usr/bin/pg_ctlcluster
       # Skip systemd when renaming and dropping
       sed -i \
         "s/'pg_ctlcluster',/'pg_ctlcluster', '--skip-systemctl-redirect',/g" \

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -6,6 +6,9 @@ execute: |
   postgresql.psql -U postgres -h /tmp -c "SELECT version();" | \
     grep "^ PostgreSQL ${SNAP_VERSION:-error}"
 
+  echo "Ensure no AppArmor denials from the snap (issue #190)..."
+  ! journalctl -k | grep 'apparmor="DENIED"' | grep 'snap\.postgresql\.'
+
   echo "Ensure all tools have been shipped.."
   postgresql.archivecleanup --help
   postgresql.basebackup --help

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -7,7 +7,7 @@ execute: |
     grep "^ PostgreSQL ${SNAP_VERSION:-error}"
 
   echo "Ensure no AppArmor denials from the snap (issue #190)..."
-  if journalctl -k | grep 'apparmor="DENIED"' | grep 'snap\.postgresql\.'; then
+  if journalctl -k | grep 'apparmor="DENIED".*oom_score_adj' | grep 'snap\.postgresql\.'; then
     echo "ERROR: AppArmor denials produced by the snap (see above)" >&2
     exit 1
   fi

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -7,7 +7,10 @@ execute: |
     grep "^ PostgreSQL ${SNAP_VERSION:-error}"
 
   echo "Ensure no AppArmor denials from the snap (issue #190)..."
-  ! journalctl -k | grep 'apparmor="DENIED"' | grep 'snap\.postgresql\.'
+  if journalctl -k | grep 'apparmor="DENIED"' | grep 'snap\.postgresql\.'; then
+    echo "ERROR: AppArmor denials produced by the snap (see above)" >&2
+    exit 1
+  fi
 
   echo "Ensure all tools have been shipped.."
   postgresql.archivecleanup --help


### PR DESCRIPTION
Ported from PG16 https://github.com/canonical/postgresql-snap/pull/193

## Issue 

Once snap `postgresql` installed, the kernel continuously logs AppArmor denials similar to:
```
audit: type=1400 audit(...): apparmor="DENIED" operation="open" class="file" profile="snap.postgresql.postgresql" name="/proc/<pid>/oom_score_adj" pid=<pid> comm="postgres" requested_mask="w" denied_mask="w" fsuid=<uid> ouid=<uid>
```
Despite these denials, PostgreSQL appears to function normally.

## Solution

pg_ctlcluster defaults PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj, making every forked backend open that file for write. Under strict confinement snapd's profile only permits reading oom_score_adj — no interface (including process-control) grants the write — so each fork logs a kernel AppArmor denial. The adjustment is a no-op in the snap anyway: the root-only -900 postmaster protection never runs because ctl-cluster.sh drops to _daemon_ via setpriv first.

Patch the staged pg_ctlcluster at build time instead of exporting PG_OOM_ADJUST_FILE=/dev/null from the wrapper: pg_ctlcluster replaces the entire environment (%ENV = read_cluster_conf_file ... 'environment') before applying the OOM default, so any wrapper export is discarded. The build-time sed changes the default itself, covers new and existing clusters alike, and remains overridable via the cluster 'environment' file.

Also extend the smoke spread test to assert the snap produces no AppArmor denials at all.

Fixes: https://github.com/canonical/postgresql-snap/issues/190

Assisted-by: Claude:claude-5-fable

(cherry picked from commit 24b9992c37587264fa32181e03aaa62db1db7e8a)