### PR TITLE
[DPE-10824] Remove duplicated concurrency on release.yaml for PG16

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 name: Release to Snap Store
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches:


### PR DESCRIPTION
## Issue:

CI fails "Release to Snap Store" due to duplicated concurrency on release.yaml and ci.yaml:

https://github.com/canonical/postgresql-snap/actions/runs/31681768006
> Canceling since a deadlock was detected for concurrency group:
> 'Release to Snap Store-refs/heads/16/edge' between a top level workflow and 'Tests'

## Solution:

Ported from https://github.com/canonical/charmed-postgresql-snap/commit/00aaf831529e279ebfd50908bd6472603e0745ca