### PR TITLE
[DPE-10781] Add PostgreSQL 18 JIT (to match apt)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,7 @@ parts:
     plugin: nil
     stage-packages:
       - postgresql-18
+      - postgresql-18-jit
       - util-linux
       - locales-all
     override-stage: |


### PR DESCRIPTION
PostgreSQL 18 has extracted Just-in-Time (JIT) compilation
( https://www.postgresql.org/docs/18/jit-reason.html )
into a dedicated postgresql-18-jit package which is installed on
Ubuntu by default due to Recommends linking:

```
>> apt info postgresql-18
> Package: postgresql-18
> Version: 18.6-0ubuntu0.26.04.1
> ...
> Recommends: postgresql-18-jit, sysstat
```

Adding it to snap to match Ubuntu APT logic
(keep SQL query speed for analytic/heavy requests).